### PR TITLE
Adds the annotations required for the project design tool

### DIFF
--- a/groups/main.bal
+++ b/groups/main.bal
@@ -24,6 +24,10 @@ public type GroupResponse record {
 
 table<GroupEntity> key(id) groups = table [];
 
+@display {
+    label: "GroupService",
+    id: "GroupService"
+}
 service / on new http:Listener(8080) {
     resource function get groups() returns GroupResponse[]|error {
         io:println("11111");

--- a/taskmgt/demo_08._bal
+++ b/taskmgt/demo_08._bal
@@ -30,8 +30,16 @@ public type TaskRequest record {
     string updatedAt;
 };
 
+@display {
+    label: "TaskMgtService",
+    id: "TaskMgtService"
+}
 service / on new http:Listener(8090) {
     resource function get tasks(string? groupTitle, string? taskStatus) returns Task[]|error {
+        @display {
+            label: "TasksService",
+            id: "TasksService"
+        }
         http:Client taskEp = check new (taskServiceUrl);
         Task[] tasks;
         if groupTitle is () {
@@ -39,6 +47,10 @@ service / on new http:Listener(8090) {
             tasks = check taskEp->get("/tasks");
         } else {
             // Type narrowing groupTitle is string == true
+            @display {
+                label: "GroupService",
+                id: "GroupService"
+            }
             http:Client taskGroupEp = check new (taskGroupServiceUrl);
             Group[] allGroups = check taskGroupEp->get("/groups");
             int[] groupIds = from var {id, title} in allGroups

--- a/tasks/main.bal
+++ b/tasks/main.bal
@@ -18,6 +18,10 @@ public type TaskResponse record {|
     string updatedAt;
 |};
 
+@display {
+    label: "TasksService",
+    id: "TasksService"
+}
 service / on new http:Listener(9090) {
     resource function post tasks(@http:Payload TaskRequest taskRequest) returns TaskResponse|error {
         return {id: 3333, title: "foobar", description: "Test task", groupId: 1234, status: "Open", createdAt: "today", updatedAt: "yesterday"};


### PR DESCRIPTION
In order to generate the service diagrams, each service should be given a unique ID to differentiate them. The current approach to do so is via the @display annotation, using a "id" field. This PR adds these required annotations.
(If a value is provided for the label, this will be used as the display name on the service node. If not provided, the service path would be used)

Also, please note that when invoking service resources, client resource actions should be used (rather than client remote method call actions).